### PR TITLE
:bug: Fixed to autoscroll to cursor after `esc` on multi-cursor selection.

### DIFF
--- a/src/text-editor.coffee
+++ b/src/text-editor.coffee
@@ -2445,6 +2445,7 @@ class TextEditor extends Model
     selections = @getSelections()
     if selections.length > 1
       selection.destroy() for selection in selections[1...(selections.length)]
+      selections[0].autoscroll()
       true
     else
       false


### PR DESCRIPTION
Before:

![before](https://cloud.githubusercontent.com/assets/185923/11204290/87acc3b6-8cba-11e5-9377-ff79d3a8bb22.gif)

After:

![after](https://cloud.githubusercontent.com/assets/185923/11204295/8cb38a5c-8cba-11e5-81cd-a78d2e46dc0d.gif)
